### PR TITLE
feat: Add 'Return to Mixer' button on Add Material page

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -966,6 +966,7 @@ def get_admin_add_material(request: Request): # Kept descriptive name
             Input(name="rho0", placeholder="Density (g/cc)", type="number", step="any"),
             Input(name="C0", placeholder="C0 (km/s)", type="number", step="any"),
             Input(name="S", placeholder="S (dimensionless)", type="number", step="any"),
+            A("Return to Mixer", href="/", role="button", cls="secondary"),
             Button("Add Material"),
             method="post",
             action="/admin/add_material" 


### PR DESCRIPTION
This commit introduces a 'Return to Mixer' button on the `/admin/add_material` page. The button allows you to easily navigate back to the main mixer page ('/') without needing to use the browser's back button.

The button is implemented as an anchor tag styled as a secondary button and is placed before the 'Add Material' button in the form.